### PR TITLE
Feature/327 51 implement transaction dao

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -34,9 +34,6 @@ dependencies {
 
     // This dependency is used to simplify JSON serialization
     implementation 'com.google.code.gson:gson:2.9.1'
-    
-    // https://mavenlibs.com/maven/dependency/org.javatuples/javatuples
-    implementation 'org.javatuples:javatuples:1.2'
 
     // This dependency is used for Email Validation
     // compile 'org.apache.commons:commons-configuration2:2.8.0'

--- a/app/src/main/java/qbnb/models/Dao.java
+++ b/app/src/main/java/qbnb/models/Dao.java
@@ -11,10 +11,10 @@ import java.util.Optional;
 public interface Dao<T> {
 
   Gson gson = new Gson();
-  
+
   /** serialize the DAO to JSON. */
   default String serialize() {
-        return gson.toJson(this);
+    return gson.toJson(this);
   }
 
   Optional<T> get(long id);

--- a/app/src/main/java/qbnb/models/Transaction.java
+++ b/app/src/main/java/qbnb/models/Transaction.java
@@ -1,7 +1,7 @@
 package qbnb.models;
 
-import java.util.Date;
 import java.time.LocalDate;
+import java.util.Date;
 
 /** Acts as a record of booking and payment when a user books a listing. */
 public class Transaction {
@@ -22,17 +22,10 @@ public class Transaction {
     listingId = listing;
     clientId = client;
     ammount = price;
+    // start & end are strings to make serialization work. They are converted
+    // from and to LocalDate when getting and setting respectively.
     this.start = start.toString();
     this.end = end.toString();
-  }
-
-  public Transaction() {
-     id = new Date().getTime();
-     listingId = 0;
-     clientId = 0;
-     ammount = 0;
-     start = LocalDate.now().toString();
-     end = LocalDate.now().toString();
   }
 
   public long getId() {
@@ -68,7 +61,7 @@ public class Transaction {
   }
 
   public void setStart(LocalDate start) {
-        this.start = start.toString();
+    this.start = start.toString();
   }
 
   public LocalDate getStart() {
@@ -76,10 +69,10 @@ public class Transaction {
   }
 
   public void setEnd(LocalDate end) {
-        this.end = end.toString();
+    this.end = end.toString();
   }
 
   public LocalDate getEnd() {
-return LocalDate.parse(end);
+    return LocalDate.parse(end);
   }
 }

--- a/app/src/main/java/qbnb/models/TransactionDao.java
+++ b/app/src/main/java/qbnb/models/TransactionDao.java
@@ -1,34 +1,21 @@
 package qbnb.models;
 
+import com.google.gson.*;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
-import java.time.LocalDate;
-import com.google.gson.*;
 
 /** Uses DAO API to act as a persistence layer for Transaction domain models. */
 public class TransactionDao implements Dao<Transaction> {
 
   private List<Transaction> transactions = new ArrayList<Transaction>();
 
- /* private Gson gson = new Gson();
-           new GsonBuilder()
-                .registerTypeHierarchyAdapter(Transaction.class, new TransactionAdapter())
-                .registerTypeHierarchyAdapter(LocalDate.class, new LocalDateAdapter())
-                .create(); */
-
   public TransactionDao(Transaction trans) {
     transactions.add(trans);
   }
 
-  /*
-  public String serialize() {
-        return gson.toJson(transactions);
-  }
-  */
-
   public static TransactionDao deserialize(String json) {
-        return gson.fromJson(json, TransactionDao.class);
+    return gson.fromJson(json, TransactionDao.class);
   }
 
   public Optional<Transaction> get(long id) {
@@ -44,7 +31,7 @@ public class TransactionDao implements Dao<Transaction> {
   }
 
   public void update(Transaction trans, String[] params) {
-        int x = 1+1;
+    int x = 1 + 1;
   }
 
   public void delete(Transaction trans) {


### PR DESCRIPTION
Implements the DAO interface in the TransactionDao which allows for serialization of classes.

The DAO interface has 1 new default method which allows for the serialization of any DAO. 

The TransactionDAO has 1 new static method which allows for the deserialization of a Transaction DAO from a JSON string.

The project has 1 new library, Gson, which allows for the simple serialization and deserialization of Java Objects to and from JSON.

Tests will need to be added to ensure that this functionality works for the TransactioDao -- and any other new Daos.

closes #51 