### PR TITLE
327-79 Fix Daos

### DIFF
--- a/app/src/main/java/qbnb/models/daos/ReviewDao.java
+++ b/app/src/main/java/qbnb/models/daos/ReviewDao.java
@@ -11,7 +11,13 @@ import qbnb.models.*;
  */
 public class ReviewDao implements Dao<Review> {
 
-  private static HashMap<Long, Review> reviews = new HashMap<Long, Review>();
+  public HashMap<Long, Review> reviews = new HashMap<Long, Review>();
+
+  public ReviewDao() {}
+
+  public ReviewDao(Review review) {
+    save(review);
+  }
 
   public boolean serialize(String reviewPath) {
     return write(reviewPath);

--- a/app/src/main/java/qbnb/models/daos/UserDao.java
+++ b/app/src/main/java/qbnb/models/daos/UserDao.java
@@ -8,7 +8,13 @@ import qbnb.models.*;
 /** Presistence layer for User instances. */
 public class UserDao implements Dao<User> {
 
-  private static HashMap<Long, User> users = new HashMap<Long, User>();
+  public HashMap<Long, User> users = new HashMap<Long, User>();
+
+  public UserDao() {}
+
+  public UserDao(User user) {
+    save(user);
+  }
 
   public boolean serialize(String userPath) {
     return write(userPath);


### PR DESCRIPTION
Changes the hash maps in each dao to public and adds a constructor method for no params and one for initializing each with an item.

Realized i needed to make the change from @datmaxo PR #77 

closes #79 