### PR TITLE
327#83 Setup docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+# base image for docker (the machine it runs on)
+FROM adoptopenjdk/openjdk11
+
+# Directory in which the following tasks are performed
+WORKDIR /home/qbnb
+# Copies all files from the root of the project to the WORKDIR
+COPY . .
+
+EXPOSE 8080
+EXPOSE 8025
+
+CMD ["./start.sh"]
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,8 @@
+version: "3.7"
+
+services:
+  app:
+    image: csus/qbnb27:a5
+    ports:
+      - 8080:8080
+      - 8025:8025

--- a/start.sh
+++ b/start.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+./gradlew run & ./gradlew runjs


### PR DESCRIPTION
adds a dockerfile to build a docker image as well as a start script to help with this. Additionally, a docker-compose file is included to make running the image easier by setting the port forwarding rules from the image to one's local machine.

closes #83 